### PR TITLE
Huge Gap above accordion__wrapper div reduced.

### DIFF
--- a/style.css
+++ b/style.css
@@ -1432,7 +1432,7 @@ input:checked + .slider .moon-icon {
   padding: 2rem;
   display: grid;
   place-items: center;
-  margin-top: 500px;
+  margin-top: 60px;
 }
 
 .accordion__wrapper {


### PR DESCRIPTION
I have reduced the gap above accordion__wrapper div . Earlier there was a gap above which was indicating some missing information  .
I reduced the gap by reducing the margin-top of container_1 to 60px instead of 500px.

Please merge this contribution.

Before:

https://github.com/user-attachments/assets/ad5d836b-8692-4223-a441-7ec8187c6656

After:

https://github.com/user-attachments/assets/0ea7018a-70fa-4dac-8dde-d08fc1bfd198



