### PR TITLE
passward show icon added

### DIFF
--- a/about.html
+++ b/about.html
@@ -105,32 +105,134 @@
     </form>
 </div>
 
- <!-- Signup Form -->
- <div class="form-popup" id="signupForm">
+   <!-- Login Form -->
+<div class="form-popup" id="loginForm">
+    <form class="form-container" onsubmit="return validateLoginForm()">
+        <h2>Login</h2>
+        <label for="loginEmail"><b>Email</b></label>
+        <input type="email" id="loginEmail" placeholder="Enter Email" name="email" required>
+        
+        <div class="form-group position-relative">
+            <label for="loginPsw"><b>Password</b></label>
+            <input type="password" id="loginPsw" placeholder="Enter Password" name="psw" required minlength="6">
+            <i class="bi bi-eye eye-icon" id="toggleLoginPassword" onclick="togglePasswordVisibility('loginPsw', 'toggleLoginPassword')"></i>
+        </div>
+
+        <button type="submit" class="btn">LOGIN</button>
+        <button type="button" class="btn cancel" onclick="closeForm('login')">CLOSE</button>
+    </form>
+</div>
+
+<!-- Signup Form -->
+<div class="form-popup" id="signupForm">
     <form class="form-container" onsubmit="return validateSignupForm()">
         <h2>Signup</h2>
+
         <div class="form-group">
             <label for="name"><b>Full Name</b></label>
             <input type="text" id="name" placeholder="Enter Full Name" name="name" required>
         </div>
+
         <div class="form-group">
             <label for="signupEmail"><b>Email</b></label>
             <input type="email" id="signupEmail" placeholder="Enter Email" name="email" required>
         </div>
-        <div class="form-group">
+
+        <div class="form-group position-relative">
             <label for="signupPsw"><b>Password</b></label>
             <input type="password" id="signupPsw" placeholder="Enter Password" name="psw" required minlength="6">
-            <span id="togglePassword" class="toggle-button">Show</span>
+            <i class="bi bi-eye eye-icon" id="toggleSignupPassword" onclick="togglePasswordVisibility('signupPsw', 'toggleSignupPassword')"></i>
         </div>
-        <div class="form-group">
+
+        <div class="form-group position-relative">
             <label for="confirmPsw"><b>Confirm Password</b></label>
             <input type="password" id="confirmPsw" placeholder="Confirm Password" name="confirmPsw" required minlength="6">
-            <span id="toggleConfirmPassword" class="toggle-button">Show</span>
+            <i class="bi bi-eye eye-icon" id="toggleConfirmPassword" onclick="togglePasswordVisibility('confirmPsw', 'toggleConfirmPassword')"></i>
         </div>
+
         <button type="submit" class="btn">SIGNUP</button>
         <button type="button" class="btn cancel" onclick="closeForm('signup')">CLOSE</button>
     </form>
 </div>
+
+<!-- Bootstrap Icons and Script for Eye Icon Functionality -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<script>
+    function togglePasswordVisibility(passwordFieldId, iconId) {
+        const passwordField = document.getElementById(passwordFieldId);
+        const togglePassword = document.getElementById(iconId);
+        if (passwordField.type === 'password') {
+            passwordField.type = 'text';
+            togglePassword.classList.remove('bi-eye');
+            togglePassword.classList.add('bi-eye-slash');
+        } else {
+            passwordField.type = 'password';
+            togglePassword.classList.remove('bi-eye-slash');
+            togglePassword.classList.add('bi-eye');
+        }
+    }
+</script>
+
+<style>
+    /* Form Container Styles */
+    .form-popup {
+        width: 400px;
+        margin: auto;
+        background-color: #ffffff;
+        border-radius: 10px;
+        padding: 20px;
+        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    }
+
+    .form-container h2 {
+        margin-bottom: 20px;
+        color: #333;
+    }
+
+    .form-control {
+        border-radius: 5px;
+        box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.1);
+        transition: border-color 0.3s;
+    }
+
+    .form-control:focus {
+        border-color: #007bff;
+        box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+    }
+
+    .btn {
+        margin-top: 15px;
+        border-radius: 5px;
+    }
+
+    .eye-icon {
+        position: absolute;
+        right: 15px;
+        top: 38px; /* Adjust according to input field height */
+        cursor: pointer;
+        color: #007bff;
+    }
+
+    .position-relative {
+        position: relative;
+    }
+
+    .btn-block {
+        width: 100%;
+    }
+
+    /* Hover Effects */
+    .btn:hover {
+        background-color: #0056b3;
+        border-color: #0056b3;
+    }
+
+    .btn.cancel:hover {
+        background-color: #6c757d;
+        border-color: #6c757d;
+    }
+</style>
+
 <script src="signup.js"></script> <!-- Link to your JavaScript file -->
 
 

--- a/blog.html
+++ b/blog.html
@@ -53,45 +53,134 @@
         <a href="#signup" class="signup-btn" onclick="openForm('signup')">Signup</a>
     </div> 
 
-    <!-- Login Form -->
+      <!-- Login Form -->
 <div class="form-popup" id="loginForm">
-    <form class="form-container" onsubmit="return validateLoginForm()">
-        <h2>Login</h2>
-        <label for="loginEmail"><b>Email</b></label>
-        <input type="email" id="loginEmail" placeholder="Enter Email" name="email" required>
-        <label for="loginPsw"><b>Password</b></label>
-        <input type="password" id="loginPsw" placeholder="Enter Password" name="psw" required minlength="6">
-        <button type="submit" class="btn">LOGIN</button>
-        <button type="button" class="btn cancel" onclick="closeForm('login')">CLOSE</button>
-    </form>
+  <form class="form-container" onsubmit="return validateLoginForm()">
+      <h2>Login</h2>
+      <label for="loginEmail"><b>Email</b></label>
+      <input type="email" id="loginEmail" placeholder="Enter Email" name="email" required>
+      
+      <div class="form-group position-relative">
+          <label for="loginPsw"><b>Password</b></label>
+          <input type="password" id="loginPsw" placeholder="Enter Password" name="psw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleLoginPassword" onclick="togglePasswordVisibility('loginPsw', 'toggleLoginPassword')"></i>
+      </div>
+
+      <button type="submit" class="btn">LOGIN</button>
+      <button type="button" class="btn cancel" onclick="closeForm('login')">CLOSE</button>
+  </form>
 </div>
 
- <!-- Signup Form -->
- <div class="form-popup" id="signupForm">
-    <form class="form-container" onsubmit="return validateSignupForm()">
-        <h2>Signup</h2>
-        <div class="form-group">
-            <label for="name"><b>Full Name</b></label>
-            <input type="text" id="name" placeholder="Enter Full Name" name="name" required>
-        </div>
-        <div class="form-group">
-            <label for="signupEmail"><b>Email</b></label>
-            <input type="email" id="signupEmail" placeholder="Enter Email" name="email" required>
-        </div>
-        <div class="form-group">
-            <label for="signupPsw"><b>Password</b></label>
-            <input type="password" id="signupPsw" placeholder="Enter Password" name="psw" required minlength="6">
-            <span id="togglePassword" class="toggle-button">Show</span>
-        </div>
-        <div class="form-group">
-            <label for="confirmPsw"><b>Confirm Password</b></label>
-            <input type="password" id="confirmPsw" placeholder="Confirm Password" name="confirmPsw" required minlength="6">
-            <span id="toggleConfirmPassword" class="toggle-button">Show</span>
-        </div>
-        <button type="submit" class="btn">SIGNUP</button>
-        <button type="button" class="btn cancel" onclick="closeForm('signup')">CLOSE</button>
-    </form>
+<!-- Signup Form -->
+<div class="form-popup" id="signupForm">
+  <form class="form-container" onsubmit="return validateSignupForm()">
+      <h2>Signup</h2>
+
+      <div class="form-group">
+          <label for="name"><b>Full Name</b></label>
+          <input type="text" id="name" placeholder="Enter Full Name" name="name" required>
+      </div>
+
+      <div class="form-group">
+          <label for="signupEmail"><b>Email</b></label>
+          <input type="email" id="signupEmail" placeholder="Enter Email" name="email" required>
+      </div>
+
+      <div class="form-group position-relative">
+          <label for="signupPsw"><b>Password</b></label>
+          <input type="password" id="signupPsw" placeholder="Enter Password" name="psw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleSignupPassword" onclick="togglePasswordVisibility('signupPsw', 'toggleSignupPassword')"></i>
+      </div>
+
+      <div class="form-group position-relative">
+          <label for="confirmPsw"><b>Confirm Password</b></label>
+          <input type="password" id="confirmPsw" placeholder="Confirm Password" name="confirmPsw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleConfirmPassword" onclick="togglePasswordVisibility('confirmPsw', 'toggleConfirmPassword')"></i>
+      </div>
+
+      <button type="submit" class="btn">SIGNUP</button>
+      <button type="button" class="btn cancel" onclick="closeForm('signup')">CLOSE</button>
+  </form>
 </div>
+
+<!-- Bootstrap Icons and Script for Eye Icon Functionality -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<script>
+  function togglePasswordVisibility(passwordFieldId, iconId) {
+      const passwordField = document.getElementById(passwordFieldId);
+      const togglePassword = document.getElementById(iconId);
+      if (passwordField.type === 'password') {
+          passwordField.type = 'text';
+          togglePassword.classList.remove('bi-eye');
+          togglePassword.classList.add('bi-eye-slash');
+      } else {
+          passwordField.type = 'password';
+          togglePassword.classList.remove('bi-eye-slash');
+          togglePassword.classList.add('bi-eye');
+      }
+  }
+</script>
+
+<style>
+  /* Form Container Styles */
+  .form-popup {
+      width: 400px;
+      margin: auto;
+      background-color: #ffffff;
+      border-radius: 10px;
+      padding: 20px;
+      box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  }
+
+  .form-container h2 {
+      margin-bottom: 20px;
+      color: #333;
+  }
+
+  .form-control {
+      border-radius: 5px;
+      box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.1);
+      transition: border-color 0.3s;
+  }
+
+  .form-control:focus {
+      border-color: #007bff;
+      box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+  }
+
+  .btn {
+      margin-top: 15px;
+      border-radius: 5px;
+  }
+
+  .eye-icon {
+      position: absolute;
+      right: 15px;
+      top: 38px; /* Adjust according to input field height */
+      cursor: pointer;
+      color: #007bff;
+  }
+
+  .position-relative {
+      position: relative;
+  }
+
+  .btn-block {
+      width: 100%;
+  }
+
+  /* Hover Effects */
+  .btn:hover {
+      background-color: #0056b3;
+      border-color: #0056b3;
+  }
+
+  .btn.cancel:hover {
+      background-color: #6c757d;
+      border-color: #6c757d;
+  }
+</style>
+
 <script src="signup.js"></script> <!-- Link to your JavaScript file -->
 
 

--- a/contact_us.html
+++ b/contact_us.html
@@ -107,92 +107,134 @@
         >
       </div>
 
-      <!-- Login Form -->
-      <div class="form-popup" id="loginForm">
-        <form class="form-container" onsubmit="return validateLoginForm()">
-          <h2>Login</h2>
-          <label for="loginEmail"><b>Email</b></label>
-          <input
-            type="email"
-            id="loginEmail"
-            placeholder="Enter Email"
-            name="email"
-            required
-          />
+        <!-- Login Form -->
+<div class="form-popup" id="loginForm">
+  <form class="form-container" onsubmit="return validateLoginForm()">
+      <h2>Login</h2>
+      <label for="loginEmail"><b>Email</b></label>
+      <input type="email" id="loginEmail" placeholder="Enter Email" name="email" required>
+      
+      <div class="form-group position-relative">
           <label for="loginPsw"><b>Password</b></label>
-          <input
-            type="password"
-            id="loginPsw"
-            placeholder="Enter Password"
-            name="psw"
-            required
-            minlength="6"
-          />
-          <button type="submit" class="btn">LOGIN</button>
-          <button type="button" class="btn cancel" onclick="closeForm('login')">
-            CLOSE
-          </button>
-        </form>
+          <input type="password" id="loginPsw" placeholder="Enter Password" name="psw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleLoginPassword" onclick="togglePasswordVisibility('loginPsw', 'toggleLoginPassword')"></i>
       </div>
 
-      <!-- Signup Form -->
-      <div class="form-popup" id="signupForm">
-        <form class="form-container" onsubmit="return validateSignupForm()">
-          <h2>Signup</h2>
-          <div class="form-group">
-            <label for="name"><b>Full Name</b></label>
-            <input
-              type="text"
-              id="name"
-              placeholder="Enter Full Name"
-              name="name"
-              required
-            />
-          </div>
-          <div class="form-group">
-            <label for="signupEmail"><b>Email</b></label>
-            <input
-              type="email"
-              id="signupEmail"
-              placeholder="Enter Email"
-              name="email"
-              required
-            />
-          </div>
-          <div class="form-group">
-            <label for="signupPsw"><b>Password</b></label>
-            <input
-              type="password"
-              id="signupPsw"
-              placeholder="Enter Password"
-              name="psw"
-              required
-              minlength="6"
-            />
-            <span id="togglePassword" class="toggle-button">Show</span>
-          </div>
-          <div class="form-group">
-            <label for="confirmPsw"><b>Confirm Password</b></label>
-            <input
-              type="password"
-              id="confirmPsw"
-              placeholder="Confirm Password"
-              name="confirmPsw"
-              required
-              minlength="6"
-            />
-            <span id="toggleConfirmPassword" class="toggle-button">Show</span>
-          </div>
-          <button type="submit" class="btn">SIGNUP</button>
-          <button
-            type="button"
-            class="btn cancel"
-            onclick="closeForm('signup')"
-          >
-            CLOSE
-          </button>
-        </form>
+      <button type="submit" class="btn">LOGIN</button>
+      <button type="button" class="btn cancel" onclick="closeForm('login')">CLOSE</button>
+  </form>
+</div>
+
+<!-- Signup Form -->
+<div class="form-popup" id="signupForm">
+  <form class="form-container" onsubmit="return validateSignupForm()">
+      <h2>Signup</h2>
+
+      <div class="form-group">
+          <label for="name"><b>Full Name</b></label>
+          <input type="text" id="name" placeholder="Enter Full Name" name="name" required>
       </div>
+
+      <div class="form-group">
+          <label for="signupEmail"><b>Email</b></label>
+          <input type="email" id="signupEmail" placeholder="Enter Email" name="email" required>
+      </div>
+
+      <div class="form-group position-relative">
+          <label for="signupPsw"><b>Password</b></label>
+          <input type="password" id="signupPsw" placeholder="Enter Password" name="psw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleSignupPassword" onclick="togglePasswordVisibility('signupPsw', 'toggleSignupPassword')"></i>
+      </div>
+
+      <div class="form-group position-relative">
+          <label for="confirmPsw"><b>Confirm Password</b></label>
+          <input type="password" id="confirmPsw" placeholder="Confirm Password" name="confirmPsw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleConfirmPassword" onclick="togglePasswordVisibility('confirmPsw', 'toggleConfirmPassword')"></i>
+      </div>
+
+      <button type="submit" class="btn">SIGNUP</button>
+      <button type="button" class="btn cancel" onclick="closeForm('signup')">CLOSE</button>
+  </form>
+</div>
+
+<!-- Bootstrap Icons and Script for Eye Icon Functionality -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<script>
+  function togglePasswordVisibility(passwordFieldId, iconId) {
+      const passwordField = document.getElementById(passwordFieldId);
+      const togglePassword = document.getElementById(iconId);
+      if (passwordField.type === 'password') {
+          passwordField.type = 'text';
+          togglePassword.classList.remove('bi-eye');
+          togglePassword.classList.add('bi-eye-slash');
+      } else {
+          passwordField.type = 'password';
+          togglePassword.classList.remove('bi-eye-slash');
+          togglePassword.classList.add('bi-eye');
+      }
+  }
+</script>
+
+<style>
+  /* Form Container Styles */
+  .form-popup {
+      width: 400px;
+      margin: auto;
+      background-color: #ffffff;
+      border-radius: 10px;
+      padding: 20px;
+      box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  }
+
+  .form-container h2 {
+      margin-bottom: 20px;
+      color: #333;
+  }
+
+  .form-control {
+      border-radius: 5px;
+      box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.1);
+      transition: border-color 0.3s;
+  }
+
+  .form-control:focus {
+      border-color: #007bff;
+      box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+  }
+
+  .btn {
+      margin-top: 15px;
+      border-radius: 5px;
+  }
+
+  .eye-icon {
+      position: absolute;
+      right: 15px;
+      top: 38px; /* Adjust according to input field height */
+      cursor: pointer;
+      color: #007bff;
+  }
+
+  .position-relative {
+      position: relative;
+  }
+
+  .btn-block {
+      width: 100%;
+  }
+
+  /* Hover Effects */
+  .btn:hover {
+      background-color: #0056b3;
+      border-color: #0056b3;
+  }
+
+  .btn.cancel:hover {
+      background-color: #6c757d;
+      border-color: #6c757d;
+  }
+</style>
+
       <script src="signup.js"></script>
       <!-- Link to your JavaScript file -->
 

--- a/index.html
+++ b/index.html
@@ -125,44 +125,133 @@
         </div> 
     
         <!-- Login Form -->
-    <div class="form-popup" id="loginForm">
-        <form class="form-container" onsubmit="return validateLoginForm()">
-            <h2>Login</h2>
-            <label for="loginEmail"><b>Email</b></label>
-            <input type="email" id="loginEmail" placeholder="Enter Email" name="email" required>
+<div class="form-popup" id="loginForm">
+    <form class="form-container" onsubmit="return validateLoginForm()">
+        <h2>Login</h2>
+        <label for="loginEmail"><b>Email</b></label>
+        <input type="email" id="loginEmail" placeholder="Enter Email" name="email" required>
+        
+        <div class="form-group position-relative">
             <label for="loginPsw"><b>Password</b></label>
             <input type="password" id="loginPsw" placeholder="Enter Password" name="psw" required minlength="6">
-            <button type="submit" class="btn">LOGIN</button>
-            <button type="button" class="btn cancel" onclick="closeForm('login')">CLOSE</button>
-        </form>
-    </div>
-    
-     <!-- Signup Form -->
-     <div class="form-popup" id="signupForm">
-        <form class="form-container" onsubmit="return validateSignupForm()">
-            <h2>Signup</h2>
-            <div class="form-group">
-                <label for="name"><b>Full Name</b></label>
-                <input type="text" id="name" placeholder="Enter Full Name" name="name" required>
-            </div>
-            <div class="form-group">
-                <label for="signupEmail"><b>Email</b></label>
-                <input type="email" id="signupEmail" placeholder="Enter Email" name="email" required>
-            </div>
-            <div class="form-group">
-                <label for="signupPsw"><b>Password</b></label>
-                <input type="password" id="signupPsw" placeholder="Enter Password" name="psw" required minlength="6">
-                <span id="togglePassword" class="toggle-button">Show</span>
-            </div>
-            <div class="form-group">
-                <label for="confirmPsw"><b>Confirm Password</b></label>
-                <input type="password" id="confirmPsw" placeholder="Confirm Password" name="confirmPsw" required minlength="6">
-                <span id="toggleConfirmPassword" class="toggle-button">Show</span>
-            </div>
-            <button type="submit" class="btn">SIGNUP</button>
-            <button type="button" class="btn cancel" onclick="closeForm('signup')">CLOSE</button>
-        </form>
-    </div>
+            <i class="bi bi-eye eye-icon" id="toggleLoginPassword" onclick="togglePasswordVisibility('loginPsw', 'toggleLoginPassword')"></i>
+        </div>
+
+        <button type="submit" class="btn">LOGIN</button>
+        <button type="button" class="btn cancel" onclick="closeForm('login')">CLOSE</button>
+    </form>
+</div>
+
+<!-- Signup Form -->
+<div class="form-popup" id="signupForm">
+    <form class="form-container" onsubmit="return validateSignupForm()">
+        <h2>Signup</h2>
+
+        <div class="form-group">
+            <label for="name"><b>Full Name</b></label>
+            <input type="text" id="name" placeholder="Enter Full Name" name="name" required>
+        </div>
+
+        <div class="form-group">
+            <label for="signupEmail"><b>Email</b></label>
+            <input type="email" id="signupEmail" placeholder="Enter Email" name="email" required>
+        </div>
+
+        <div class="form-group position-relative">
+            <label for="signupPsw"><b>Password</b></label>
+            <input type="password" id="signupPsw" placeholder="Enter Password" name="psw" required minlength="6">
+            <i class="bi bi-eye eye-icon" id="toggleSignupPassword" onclick="togglePasswordVisibility('signupPsw', 'toggleSignupPassword')"></i>
+        </div>
+
+        <div class="form-group position-relative">
+            <label for="confirmPsw"><b>Confirm Password</b></label>
+            <input type="password" id="confirmPsw" placeholder="Confirm Password" name="confirmPsw" required minlength="6">
+            <i class="bi bi-eye eye-icon" id="toggleConfirmPassword" onclick="togglePasswordVisibility('confirmPsw', 'toggleConfirmPassword')"></i>
+        </div>
+
+        <button type="submit" class="btn">SIGNUP</button>
+        <button type="button" class="btn cancel" onclick="closeForm('signup')">CLOSE</button>
+    </form>
+</div>
+
+<!-- Bootstrap Icons and Script for Eye Icon Functionality -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<script>
+    function togglePasswordVisibility(passwordFieldId, iconId) {
+        const passwordField = document.getElementById(passwordFieldId);
+        const togglePassword = document.getElementById(iconId);
+        if (passwordField.type === 'password') {
+            passwordField.type = 'text';
+            togglePassword.classList.remove('bi-eye');
+            togglePassword.classList.add('bi-eye-slash');
+        } else {
+            passwordField.type = 'password';
+            togglePassword.classList.remove('bi-eye-slash');
+            togglePassword.classList.add('bi-eye');
+        }
+    }
+</script>
+
+<style>
+    /* Form Container Styles */
+    .form-popup {
+        width: 400px;
+        margin: auto;
+        background-color: #ffffff;
+        border-radius: 10px;
+        padding: 20px;
+        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    }
+
+    .form-container h2 {
+        margin-bottom: 20px;
+        color: #333;
+    }
+
+    .form-control {
+        border-radius: 5px;
+        box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.1);
+        transition: border-color 0.3s;
+    }
+
+    .form-control:focus {
+        border-color: #007bff;
+        box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+    }
+
+    .btn {
+        margin-top: 15px;
+        border-radius: 5px;
+    }
+
+    .eye-icon {
+        position: absolute;
+        right: 15px;
+        top: 38px; /* Adjust according to input field height */
+        cursor: pointer;
+        color: #007bff;
+    }
+
+    .position-relative {
+        position: relative;
+    }
+
+    .btn-block {
+        width: 100%;
+    }
+
+    /* Hover Effects */
+    .btn:hover {
+        background-color: #0056b3;
+        border-color: #0056b3;
+    }
+
+    .btn.cancel:hover {
+        background-color: #6c757d;
+        border-color: #6c757d;
+    }
+</style>
+
     <script src="signup.js"></script> <!-- Link to your JavaScript file -->
 
     

--- a/start.html
+++ b/start.html
@@ -50,36 +50,133 @@
         <a href="#signup" class="signup-btn" onclick="openForm('signup')">Signup</a>
     </div>
 
-    <!-- Login Form -->
+     <!-- Login Form -->
 <div class="form-popup" id="loginForm">
-    <form class="form-container" onsubmit="return validateLoginForm()">
-        <h2>Login</h2>
-        <label for="loginEmail"><b>Email</b></label>
-        <input type="email" id="loginEmail" placeholder="Enter Email" name="email" required>
-        <label for="loginPsw"><b>Password</b></label>
-        <input type="password" id="loginPsw" placeholder="Enter Password" name="psw" required minlength="6">
-        <button type="submit" class="btn">LOGIN</button>
-        <button type="button" class="btn cancel" onclick="closeForm('login')">CLOSE</button>
-    </form>
+  <form class="form-container" onsubmit="return validateLoginForm()">
+      <h2>Login</h2>
+      <label for="loginEmail"><b>Email</b></label>
+      <input type="email" id="loginEmail" placeholder="Enter Email" name="email" required>
+      
+      <div class="form-group position-relative">
+          <label for="loginPsw"><b>Password</b></label>
+          <input type="password" id="loginPsw" placeholder="Enter Password" name="psw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleLoginPassword" onclick="togglePasswordVisibility('loginPsw', 'toggleLoginPassword')"></i>
+      </div>
+
+      <button type="submit" class="btn">LOGIN</button>
+      <button type="button" class="btn cancel" onclick="closeForm('login')">CLOSE</button>
+  </form>
 </div>
 
 <!-- Signup Form -->
 <div class="form-popup" id="signupForm">
-    <form class="form-container" onsubmit="return validateSignupForm()">
-        <h2>Signup</h2>
-        <label for="name"><b>Full Name</b></label>
-        <input type="text" id="name" placeholder="Enter Full Name" name="name" required>
-        <label for="signupEmail"><b>Email</b></label>
-        <input type="email" id="signupEmail" placeholder="Enter Email" name="email" required>
-        <label for="signupPsw"><b>Password</b></label>
-        <input type="password" id="signupPsw" placeholder="Enter Password" name="psw" required minlength="6">
-        <label for="confirmPsw"><b>Confirm Password</b></label>
-        <input type="password" id="confirmPsw" placeholder="Confirm Password" name="confirmPsw" required minlength="6">
-        <button type="submit" class="btn">SIGNUP</button>
-        <button type="button" class="btn cancel" onclick="closeForm('signup')">CLOSE</button>
-    </form>
+  <form class="form-container" onsubmit="return validateSignupForm()">
+      <h2>Signup</h2>
+
+      <div class="form-group">
+          <label for="name"><b>Full Name</b></label>
+          <input type="text" id="name" placeholder="Enter Full Name" name="name" required>
+      </div>
+
+      <div class="form-group">
+          <label for="signupEmail"><b>Email</b></label>
+          <input type="email" id="signupEmail" placeholder="Enter Email" name="email" required>
+      </div>
+
+      <div class="form-group position-relative">
+          <label for="signupPsw"><b>Password</b></label>
+          <input type="password" id="signupPsw" placeholder="Enter Password" name="psw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleSignupPassword" onclick="togglePasswordVisibility('signupPsw', 'toggleSignupPassword')"></i>
+      </div>
+
+      <div class="form-group position-relative">
+          <label for="confirmPsw"><b>Confirm Password</b></label>
+          <input type="password" id="confirmPsw" placeholder="Confirm Password" name="confirmPsw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleConfirmPassword" onclick="togglePasswordVisibility('confirmPsw', 'toggleConfirmPassword')"></i>
+      </div>
+
+      <button type="submit" class="btn">SIGNUP</button>
+      <button type="button" class="btn cancel" onclick="closeForm('signup')">CLOSE</button>
+  </form>
 </div>
 
+<!-- Bootstrap Icons and Script for Eye Icon Functionality -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<script>
+  function togglePasswordVisibility(passwordFieldId, iconId) {
+      const passwordField = document.getElementById(passwordFieldId);
+      const togglePassword = document.getElementById(iconId);
+      if (passwordField.type === 'password') {
+          passwordField.type = 'text';
+          togglePassword.classList.remove('bi-eye');
+          togglePassword.classList.add('bi-eye-slash');
+      } else {
+          passwordField.type = 'password';
+          togglePassword.classList.remove('bi-eye-slash');
+          togglePassword.classList.add('bi-eye');
+      }
+  }
+</script>
+
+<style>
+  /* Form Container Styles */
+  .form-popup {
+      width: 400px;
+      margin: auto;
+      background-color: #ffffff;
+      border-radius: 10px;
+      padding: 20px;
+      box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  }
+
+  .form-container h2 {
+      margin-bottom: 20px;
+      color: #333;
+  }
+
+  .form-control {
+      border-radius: 5px;
+      box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.1);
+      transition: border-color 0.3s;
+  }
+
+  .form-control:focus {
+      border-color: #007bff;
+      box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+  }
+
+  .btn {
+      margin-top: 15px;
+      border-radius: 5px;
+  }
+
+  .eye-icon {
+      position: absolute;
+      right: 15px;
+      top: 38px; /* Adjust according to input field height */
+      cursor: pointer;
+      color: #007bff;
+  }
+
+  .position-relative {
+      position: relative;
+  }
+
+  .btn-block {
+      width: 100%;
+  }
+
+  /* Hover Effects */
+  .btn:hover {
+      background-color: #0056b3;
+      border-color: #0056b3;
+  }
+
+  .btn.cancel:hover {
+      background-color: #6c757d;
+      border-color: #6c757d;
+  }
+</style>
 
     <div class="theme-switch-wrapper">
         <label class="theme-switch" for="checkbox">

--- a/start_writing.html
+++ b/start_writing.html
@@ -74,38 +74,134 @@
                 <a href="#signup" class="signup-btn" onclick="openForm('signup')">Signup</a>
             </div> 
         
-            <!-- Login Form -->
-        <div class="form-popup" id="loginForm">
-            <form class="form-container" onsubmit="return validateLoginForm()">
-                <h2>Login</h2>
-                <label for="loginEmail"><b>Email</b></label>
-                <input type="email" id="loginEmail" placeholder="Enter Email" name="email" required>
-                <label for="loginPsw"><b>Password</b></label>
-                <input type="password" id="loginPsw" placeholder="Enter Password" name="psw" required minlength="6">
-                <button type="submit" class="btn">LOGIN</button>
-                <button type="button" class="btn cancel" onclick="closeForm('login')">CLOSE</button>
-            </form>
-        </div>
+             <!-- Login Form -->
+<div class="form-popup" id="loginForm">
+  <form class="form-container" onsubmit="return validateLoginForm()">
+      <h2>Login</h2>
+      <label for="loginEmail"><b>Email</b></label>
+      <input type="email" id="loginEmail" placeholder="Enter Email" name="email" required>
+      
+      <div class="form-group position-relative">
+          <label for="loginPsw"><b>Password</b></label>
+          <input type="password" id="loginPsw" placeholder="Enter Password" name="psw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleLoginPassword" onclick="togglePasswordVisibility('loginPsw', 'toggleLoginPassword')"></i>
+      </div>
 
-        <div class="auth-buttons">
-          <div class="nav-item dropdown" style="list-style-type: none">
-            <button class="dropbtn">
-              <img
-                width="30px"
-                src="images/profile.png"
-                alt="Profile"
-                class="profile-icon"
-                onclick="toggleDropdown()"
-              />
-            </button>
-            <div id="profile-dropdown" class="dropdown-content">
-              <div class="login-signup-form">
-                <a href="login.html">Log In</a>
-                <a href="signup.html">Sign Up</a>
-              </div>
-            </div>
-          </div>
-        </div>
+      <button type="submit" class="btn">LOGIN</button>
+      <button type="button" class="btn cancel" onclick="closeForm('login')">CLOSE</button>
+  </form>
+</div>
+
+<!-- Signup Form -->
+<div class="form-popup" id="signupForm">
+  <form class="form-container" onsubmit="return validateSignupForm()">
+      <h2>Signup</h2>
+
+      <div class="form-group">
+          <label for="name"><b>Full Name</b></label>
+          <input type="text" id="name" placeholder="Enter Full Name" name="name" required>
+      </div>
+
+      <div class="form-group">
+          <label for="signupEmail"><b>Email</b></label>
+          <input type="email" id="signupEmail" placeholder="Enter Email" name="email" required>
+      </div>
+
+      <div class="form-group position-relative">
+          <label for="signupPsw"><b>Password</b></label>
+          <input type="password" id="signupPsw" placeholder="Enter Password" name="psw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleSignupPassword" onclick="togglePasswordVisibility('signupPsw', 'toggleSignupPassword')"></i>
+      </div>
+
+      <div class="form-group position-relative">
+          <label for="confirmPsw"><b>Confirm Password</b></label>
+          <input type="password" id="confirmPsw" placeholder="Confirm Password" name="confirmPsw" required minlength="6">
+          <i class="bi bi-eye eye-icon" id="toggleConfirmPassword" onclick="togglePasswordVisibility('confirmPsw', 'toggleConfirmPassword')"></i>
+      </div>
+
+      <button type="submit" class="btn">SIGNUP</button>
+      <button type="button" class="btn cancel" onclick="closeForm('signup')">CLOSE</button>
+  </form>
+</div>
+
+<!-- Bootstrap Icons and Script for Eye Icon Functionality -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
+<script>
+  function togglePasswordVisibility(passwordFieldId, iconId) {
+      const passwordField = document.getElementById(passwordFieldId);
+      const togglePassword = document.getElementById(iconId);
+      if (passwordField.type === 'password') {
+          passwordField.type = 'text';
+          togglePassword.classList.remove('bi-eye');
+          togglePassword.classList.add('bi-eye-slash');
+      } else {
+          passwordField.type = 'password';
+          togglePassword.classList.remove('bi-eye-slash');
+          togglePassword.classList.add('bi-eye');
+      }
+  }
+</script>
+
+<style>
+  /* Form Container Styles */
+  .form-popup {
+      width: 400px;
+      margin: auto;
+      background-color: #ffffff;
+      border-radius: 10px;
+      padding: 20px;
+      box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  }
+
+  .form-container h2 {
+      margin-bottom: 20px;
+      color: #333;
+  }
+
+  .form-control {
+      border-radius: 5px;
+      box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.1);
+      transition: border-color 0.3s;
+  }
+
+  .form-control:focus {
+      border-color: #007bff;
+      box-shadow: 0 0 5px rgba(0, 123, 255, 0.5);
+  }
+
+  .btn {
+      margin-top: 15px;
+      border-radius: 5px;
+  }
+
+  .eye-icon {
+      position: absolute;
+      right: 15px;
+      top: 38px; /* Adjust according to input field height */
+      cursor: pointer;
+      color: #007bff;
+  }
+
+  .position-relative {
+      position: relative;
+  }
+
+  .btn-block {
+      width: 100%;
+  }
+
+  /* Hover Effects */
+  .btn:hover {
+      background-color: #0056b3;
+      border-color: #0056b3;
+  }
+
+  .btn.cancel:hover {
+      background-color: #6c757d;
+      border-color: #6c757d;
+  }
+</style>
+
 
         <div class="theme-switch-wrapper">
           <label class="theme-switch" for="checkbox">


### PR DESCRIPTION
## Description

I have added an eye button next to the password field to toggle between showing and hiding the password. This improves the user experience by allowing users to verify their password as they type.

### Screenshots

#### With Password Hidden
![image](https://github.com/user-attachments/assets/f633d715-2c90-4f4d-878b-d0bf6706aca0)


#### With Password Shown
![image](https://github.com/user-attachments/assets/e1875c9a-97fe-4566-9de1-b9d9fabbaeba)


## Issue Link

Fixes #541 

---

### Changes Made:
- Added an eye icon next to the password field.
- Implemented JavaScript logic to toggle password visibility.
- Styled the eye icon using CSS.

### Checklist:
- [x] I have added screenshots and videos to show before and after the working of my code.
- [x] I have ensured that the screen size is set to 100% while making the video.
- [x] I have synced the latest fork with my local repository and resolved any conflicts.
- [x] I have mentioned the issue number which I created before making this PR (format: fixes #(issue number)).
- [x] I understand that if any of the above conditions are not met, my PR will not be merged.
