### PR TITLE
separate cards for blog content and blog description

### DIFF
--- a/start_writing.css
+++ b/start_writing.css
@@ -1,26 +1,36 @@
-
-.blog-form-container {
-    background: url('/path-to-your-uploaded-image') no-repeat center center;
-    background-size: cover;
-    padding: 30px;
-    border-radius: 10px;
-    max-width: 800px;
-    margin: 20px auto;
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
-    transition: background-color 0.3s ease;
+/* Center the heading and move it up */
+.blog-form-container h2 {
+  text-align: center; /* Center the text itself */
+  margin-top: 0; /* Remove any default top margin */
+  margin-bottom: 15px; /* Keep the bottom margin as is */
+  padding-bottom: 60px; /* Optional: Add some padding from the top */
+  padding-right: 120px;
 }
 
-/* Input, Textarea, and Select Styling */
-form input, form select, form textarea {
-    width: 100%;
-    padding: 12px;
-    margin: 10px 0 20px;
-    border: none;
-    border-radius: 8px;
-    box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
-    font-size: 1rem;
+*{
+  box-sizing:border-box;
+  margin: 0;
+  padding: 0;
 }
 
+/*container for both cards */
+.card-container{
+  display:flex;
+  justify-content: space-evenly;
+  flex-wrap: wrap;
+  max-width:1200px;
+  margin:20px auto;
+}
+.card {
+  background: url('/path-to-your-uploaded-image') no-repeat center center;
+  background-size: cover;
+  padding: 30px;
+  border-radius: 10px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.3s ease;
+  width: 48%; /* Makes each card take 48% of the width */
+  box-sizing: border-box;
+}
 /* Theme-specific Adjustments */
 body.dark-mode .blog-form-container {
     background-color: rgba(34, 33, 33, 0.6);
@@ -29,6 +39,17 @@ body.dark-mode .blog-form-container {
 body.light-mode .blog-form-container {
     background-color: rgba(0, 0, 0, 0.6);
     color: #333;
+}
+/* Input, Textarea, and Select Styling */
+form input, form select, form textarea {
+  width: 450px;
+  max-height: 400px;
+  padding: 10px;
+  margin: 10px 0 20px;
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
+  font-size: 1rem;
 }
 
 /* Button Styling */
@@ -44,12 +65,18 @@ form button[type="submit"] {
 form button[type="submit"]:hover {
     background-color: #e65c00;
 }
-
 /* Placeholder for blog content */
-textarea#blogContent::placeholder {
-    content: "Write a sample blog to give an idea of size";
+textarea {
+    height: 400px;
+    width: calc(100%-24px);
+    padding: 12px;
+    border: none;
+    border-radius: 8px;
+    box-shadow: 0px 2px 5px rgba(0,0,0,0.1);
+    font-size:1rem;
+    margin-bottom: 20px;
+    overflow-y: auto;
 }
-
 /* Popup styling for success */
 #popupMessage {
   display: block; /* Ensure it's set to block */
@@ -79,7 +106,6 @@ textarea#blogContent::placeholder {
   top: 10px;
 }
 
-
 #suggestionsContainer {
   background-color: #f9f9f9;
   padding: 15px;
@@ -87,20 +113,18 @@ textarea#blogContent::placeholder {
   box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
   display: none;  /* Initially hidden */
 }
-
 #suggestionsContainer h4 {
   margin-bottom: 10px;
 }
-
 #suggestionsText {
   font-size: 1rem;
   color: #333;
 }
-
 /* Show the suggestions when available */
 #suggestionsContainer.visible {
   display: block;
 }
+
 
 @keyframes fadeOut {
   0% {
@@ -112,6 +136,50 @@ textarea#blogContent::placeholder {
   100% {
       opacity: 0;
   }
+}
+/* specific height adjustments for each card */
+.card:nth-child(1){
+  width:500px;
+  height: 350px;
+}
+.card:nth-child(2){
+  height:700px;
+  width: auto;
+}
+
+/* Responsive Styles */
+@media (max-width: 768px) {
+    .card {
+        width: 100%; /* Full width on smaller screens */
+        height: auto; /* Adjust height to auto */
+    }
+
+    form input, form select, form textarea {
+        width: calc(100% - 24px); /* Full width with padding */
+    }
+
+    .blog-form-container h2 {
+        padding-right: 0; /* Remove extra padding on smaller screens */
+    }
+
+    #suggestionsContainer {
+        width: calc(100% - 24px); /* Full width for suggestions on smaller screens */
+    }
+}
+
+@media (max-width: 480px) {
+    /* Further adjustments for mobile */
+    .card {
+        padding: 20px; /* Reduce padding */
+    }
+
+    form button[type="submit"] {
+        width: 100%; /* Full width for submit button */
+    }
+
+    textarea {
+        height: 300px; /* Adjust height for mobile */
+    }
 }
 
 

--- a/start_writing.html
+++ b/start_writing.html
@@ -314,7 +314,11 @@
         <form id="blogForm" onsubmit="PostBlog(event)">
           <h2 style="margin-bottom: 15px">Start Writing</h2>
 
-          <label for="blogHeading">Blog Heading:</label>
+          <div class="card-container">
+          <!--card 1: Blog Heading , Topic and Image upload-->
+
+          <div class="card">
+          <label for="blogHeading">Blog Heading</label>
           <input
             type="text"
             id="blogHeading"
@@ -323,7 +327,7 @@
             required
           />
 
-          <label for="blogTopic">Select Topic:</label>
+          <label for="blogTopic">Select Topic</label>
           <select id="blogTopic" name="topic" required>
             <option value="" disabled selected>Select a topic</option>
             <option value="Travel">Travel</option>
@@ -331,15 +335,19 @@
             <option value="Lifestyle">Lifestyle</option>
           </select>
 
-          <label for="blogImage">Upload Image:</label>
+          <label for="blogImage">Upload Image</label>
           <input type="file" id="blogImage" name="image" accept="image/*" />
+          </div>
 
-          <label for="blogContent">Blog Content:</label>
-<div style="position: relative;">
+
+          <!--card 2 : Blog content , writer name , submit button-->
+          <div class = "card"> 
+          <label for="blogContent">Blog Content</label>
+        <div style="position: relative;">
     <textarea
         id="blogContent"
         name="content"
-        rows="10"
+        rows="20"
         placeholder="Start writing your blog here..."
         required
     ></textarea>
@@ -353,10 +361,10 @@
 
 <!-- Placeholder to show the suggestions -->
 <div id="suggestionsContainer" style="margin-top: 15px;">
-    <h4>Suggestions:</h4>
+    <h4>Suggestions</h4>
     <p id="suggestionsText">Your suggestions will appear here...</p>
 </div>
-          <label for="writerName">Your Name:</label>
+          <label for="writerName">Your Name</label>
           <input
             type="text"
             id="writerName"
@@ -366,6 +374,8 @@
           />
 
           <button type="submit">Submit Blog</button>
+          </div>
+          </div>
         </form>
       </div>
     </main>


### PR DESCRIPTION

Issue No #731 
Description 

In the latest update to the "Start Writing" tab, I've implemented significant design improvements aimed at enhancing user experience and increasing focus on the main content—the blog post itself. Previously, the content was contained within a single container, which often led to a cluttered interface and made it challenging for users to concentrate on the primary task of writing.

The content has been restructured into two separate containers: one for the blog content and another for supplementary information or tools. This separation creates a clearer visual hierarchy, allowing users to focus on the blog content without distractions. By dividing the interface this way, users can more easily differentiate between the main writing area and additional features, leading to a more streamlined writing process. The redesign emphasizes visual context by utilizing distinct layouts and styles for each container. This not only improves the overall aesthetics but also guides users’ attention to the most critical aspects of the writing experience.  

before image
![before](https://github.com/user-attachments/assets/752e1a2a-0451-4803-a083-5d2f6c2fa961)

after image 
![after](https://github.com/user-attachments/assets/49dc1bb7-236a-4171-9d29-3cc49f5a8118)

- I have added screenshots  to show before and after working of my code
- I have synced the latest fork with my local repository and resolved my conflicts
- mentioned the issue number which i created before making this PR
