### PR TITLE
Adjusted the images on index.html

### DIFF
--- a/style.css
+++ b/style.css
@@ -2242,6 +2242,7 @@ a {
 .overflow-img img {
   width: 100%;
   height: auto;
+  object-fit: cover;
 }
 
 .overflow-img:hover {


### PR DESCRIPTION
Fixes #1079
Issue: Stretched images on index.html
I've fixed the issue of stretched images on index.html through this PR.

Before:
![Screenshot (686)](https://github.com/user-attachments/assets/6535b4b3-2225-4741-b1b8-9ebfda1f3d91)
![Screenshot (687)](https://github.com/user-attachments/assets/bf483de1-8aaf-4881-8130-cdf216b63cb9)


After:
![Screenshot (688)](https://github.com/user-attachments/assets/e91e117c-60e8-4b60-9179-77a4fbc8323f)
![Screenshot (689)](https://github.com/user-attachments/assets/1a0e2f5b-bd54-4eaf-98c8-df95e97980b2)

### Pull Request Checklist

- [x] I have added screenshots and videos to show before and after the working of my code.
- [x] I have ensured that the screen size is set to 100% while making the video.
- [x] I have synced the latest fork with my local repository and resolved any conflicts.
- [x] I have mentioned the issue number which I created before making this PR .(format to mention issue number is : fixes #(issue number) ) 
- [x] I understand that if any the above conditions are not met , my PR will not be MERGED .

Looking forward to merge this PR.
Kindly add the tags of hacktoberfest, hacktoberfest-accepted and gssoc-ext.