### PR TITLE
[FIXED] Page not scrolling on Start Writing page #1334

### DIFF
--- a/style.css
+++ b/style.css
@@ -331,7 +331,6 @@ body {
   font-family: Arial, sans-serif;
   background-color: var(--background-color);
   max-width: 100%; /* Ensure container does not overflow */
-  overflow: hidden;
 }
 
 /* Hide scrollbar for main body */


### PR DESCRIPTION
## Related Issue:
- #1334 

Fixes #1334 

## Description:
The scrolling feature on the Start Writing page wasn't available and as a result the users weren't able to access the contents present down below and not able to write or post new blogs. This issue was fixed by removing the overflow condition that prevented the scrolling of the page.

## Screenshots / Videos:

https://github.com/user-attachments/assets/e0be1f24-4251-464d-ae37-eeb692ec7495


## Pull Request Checklist

- [X] I have added screenshots and videos to show before and after the working of my code.
- [X] I have ensured that the screen size is set to 100% while making the video.
- [X] I have synced the latest fork with my local repository and resolved any conflicts.
- [X] I have mentioned the issue number which I created before making this PR .(format to mention issue number is : fixes #(issue number) ) 
- [X] I understand that if any the above conditions are not met , my PR will not be MERGED .

