### PR TITLE
Added trusted email validation functionality in contact us page

### DIFF
--- a/contact_us.js
+++ b/contact_us.js
@@ -4,11 +4,32 @@ document.addEventListener("DOMContentLoaded", () => {
   sendEmailButton.addEventListener("click", SendEmail);
 });
 
+const trustedDomains = [
+  'gmail.com', 'outlook.com', 'yahoo.com', 
+  'protonmail.com', 'icloud.com', 'tutanota.com',
+  'hotmail.com', 'live.com', 'mail.com', 
+  'zoho.com', 'gmx.com', 'aol.com', 'fastmail.com', 
+  'yandex.com', '*.edu', '*.ac.uk'
+];
+
+// Email validation function to check format and domain
+function validateEmail(email) {
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // Basic email format validation
+  const domain = email.split('@')[1];
+
+  return (
+    emailPattern.test(email) && 
+    trustedDomains.some((trusted) => 
+      trusted.includes('*') ? domain.endsWith(trusted.slice(1)) : domain === trusted
+    )
+  );
+}
+
 async function SendEmail(event) {
   event.preventDefault();
 
-  const Name = document.getElementById("Name").value.trim(); // Corrected ID
-  const email = document.getElementById("email2").value.trim(); // Corrected ID
+  const Name = document.getElementById("Name").value.trim();
+  const email = document.getElementById("email2").value.trim();
   const phone = document.getElementById("phone").value.trim();
   const message = document.getElementById("message").value.trim();
 
@@ -19,23 +40,16 @@ async function SendEmail(event) {
   }
 
   if (!validateEmail(email)) {
-    alert("Please enter a valid email address.");
+    alert("Please enter a valid email address from a trusted provider.");
     return;
   }
-
-  console.log(Name, email, phone, message); // Corrected variable name
 
   if (message.length < 10) {
     alert("Message must be at least 10 characters long.");
     return;
   }
 
-  const data = {
-    Name: Name,
-    email: email,
-    phone: phone,
-    message: message,
-  };
+  const data = { Name, email, phone, message };
 
   try {
     const response = await fetch("http://127.0.0.1:3000/send-email", {
@@ -52,7 +66,6 @@ async function SendEmail(event) {
     } else {
       handleErrorResponse(result);
     }
-    
   } catch (error) {
     console.error("Error sending email:", error);
     alert("Error sending email. Please try again later.");

--- a/contact_us.js
+++ b/contact_us.js
@@ -5,15 +5,32 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 const trustedDomains = [
-  'gmail.com', 'outlook.com', 'yahoo.com', 
-  'protonmail.com', 'icloud.com', 'tutanota.com',
-  'hotmail.com', 'live.com', 'mail.com', 
-  'zoho.com', 'gmx.com', 'aol.com', 'fastmail.com', 
-  'yandex.com', '*.edu', '*.ac.uk'
+  'gmail.com',
+  'outlook.com',
+  'yahoo.com',
+  'protonmail.com',
+  'icloud.com',
+  'tutanota.com',
+  'hotmail.com',
+  'live.com',
+  'mail.com',
+  'zoho.com',
+  'gmx.com',
+  'aol.com',
+  'fastmail.com',
+  'yandex.com',
+  '*.edu',
+  '*.ac.uk',
+  '*.edu.in',
+  '*.edu.au',
+  'examplecompany.com',
+  'mailfence.com',
+  'posteo.de',
+  'runbox.com'
 ];
 
 // Email validation function to check format and domain
-function validateEmail(email) {
+function ValidateTrustEmail(email) {
   const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // Basic email format validation
   const domain = email.split('@')[1];
 
@@ -39,7 +56,7 @@ async function SendEmail(event) {
     return;
   }
 
-  if (!validateEmail(email)) {
+  if (!ValidateTrustEmail(email)) {
     alert("Please enter a valid email address from a trusted provider.");
     return;
   }


### PR DESCRIPTION
### PR Description: Implemented Email Domain Validation in Contact Form  

Fixes #1470

1. Added validation to allow only trusted email domains: `gmail.com`, `outlook.com`, `yahoo.com`, `protonmail.com`, `icloud.com`, `tutanota.com`, and more.  
2. Displays an alert message if the email is from an untrusted domain and blocks submission.  
3. Ensures data integrity by filtering spam and temporary emails. 

@ANSHIKA-26 
Pls add level, gssoc-extd, hacktoberfest-accepted.