### PR TITLE
Added Trusted email validation functionality in feedback form

### DIFF
--- a/give_feedback.html
+++ b/give_feedback.html
@@ -553,6 +553,44 @@ main
     const closePopup = document.getElementById('closePopup');
     const feedbackResult = document.getElementById('feedback-result');
 
+      const trustedDomains = [
+      'gmail.com',
+      'outlook.com',
+      'yahoo.com',
+      'protonmail.com',
+      'icloud.com',
+      'tutanota.com',
+      'hotmail.com',
+      'live.com',
+      'mail.com',
+      'zoho.com',
+      'gmx.com',
+      'aol.com',
+      'fastmail.com',
+      'yandex.com',
+      '*.edu',
+      '*.ac.uk',
+      '*.edu.in',
+      '*.edu.au',
+      'examplecompany.com',
+      'mailfence.com',
+      'posteo.de',
+      'runbox.com'
+  ];
+
+  // Email validation function to check format and domain
+  function validateEmail(email) {
+      const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // Basic email format validation
+      const domain = email.split('@')[1];
+
+      return (
+          emailPattern.test(email) && 
+          trustedDomains.some((trusted) => 
+              trusted.includes('*') ? domain.endsWith(trusted.slice(1)) : domain === trusted
+          )
+      );
+  }
+
     submitBtn.addEventListener('click', () => {
       const name = document.getElementById('Name').value.trim();
       const email = document.getElementById('email2').value.trim();
@@ -579,6 +617,11 @@ if (message === '') {
     alert('Please enter a feedback message!');
     return; // Stop execution if name is empty
 }
+if (!validateEmail(email)) {
+        alert('Please enter a valid email address from a trusted provider.');
+        return;
+    }
+
       
       // Display feedback result in popup
       feedbackResult.innerHTML = `Thank you, ${name}!<br>Your feedback: ${message}<br>Rating: ${rating} stars`;


### PR DESCRIPTION
### PR Description: Implemented Email Domain Validation in Feedback Form  

Fixes #1485

1. Added validation to allow only trusted email domains: `gmail.com`, `outlook.com`, `yahoo.com`, `protonmail.com`, `icloud.com`, `tutanota.com`, and more.  
2. Displays an alert message if the email is from an untrusted domain and blocks submission.  
3. Ensures data integrity by filtering spam and temporary emails. 

@ANSHIKA-26 
Pls add level, gssoc-extd, hacktoberfest-accepted.