### PR TITLE
Fix invisible text in the "Message" field on the Contact page

### DIFF
--- a/contact_us.html
+++ b/contact_us.html
@@ -474,7 +474,7 @@
       </div>
 
       <div class="form-group" style="margin-bottom: 20px">
-        <textarea id="message" name="message" rows="4" placeholder="Message" required style="
+        <textarea id="message" name="message" placeholder="Message" required style="
           width: 100%;
           padding: 10px 0;
           font-size: 16px;
@@ -483,8 +483,8 @@
           border-radius: 0px;
           border: none;
           border-bottom: 2px solid var(--text-color);
-          outline: none;
-        "></textarea>
+          outline: none;"></textarea>
+     
       </div>
 
       <button type="button" onclick="SendEmail(event)" class="submitbtn">


### PR DESCRIPTION
Fixes Issue: #1555

# Description of the bug
On the Contact page, when users type in the "Message" field, the input text does not appear. This lack of visibility prevents users from reviewing their message, which could lead to incomplete or incorrect submissions.

# Steps to Reproduce
1. Go to the Contact page.
2. Click on the "Message" field and start typing.
3. Notice that the input text is not visible.

# Expected Behavior
When typing in the "Message" field, the input text should appear, allowing users to see what they are typing.

# Fix Details
This PR addresses the issue by ensuring that the textarea for the "Message" field has the correct styling. The color and background-color properties are updated to provide sufficient contrast. Additionally, any potential CSS overrides are managed with !important flags to prevent other styles from impacting the text visibility.

# Screenshots
<img width="1434" alt="Screenshot 2024-10-31 at 10 21 34 PM" src="https://github.com/user-attachments/assets/f2432438-d468-435b-8fbc-f94265ecdcab">



### Pull Request Checklist

- [x] I have added screenshots and videos to show before and after the working of my code.
- [x] I have ensured that the screen size is set to 100% while making the video.
- [x] I have synced the latest fork with my local repository and resolved any conflicts.
- [x] I have mentioned the issue number which I created before making this PR .(format to mention issue number is : fixes #(issue number) ) 
- [x] I understand that if any the above conditions are not met , my PR will not be MERGED .

